### PR TITLE
Update value to semantic versioning

### DIFF
--- a/custom_components/voicerss/manifest.json
+++ b/custom_components/voicerss/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "voicerss",
   "name": "VoiceRSS",
-  "version": "v1.00",
   "documentation": "https://www.home-assistant.io/integrations/voicerss",
   "config_flow": false,
   "codeowners": [
     "@nagyrobi"
-  ]
+  ],
+  "version": "1.0.1",
 }


### PR DESCRIPTION
logs after upgrading to 2021.5:
No 'version' key in the manifest file for custom integration 'voicerss'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'voicerss'

https://www.home-assistant.io/blog/2021/05/05/release-20215/#breaking-changes
https://github.com/home-assistant/core/pull/49726